### PR TITLE
Add server environment modules

### DIFF
--- a/server_env_storage_backend/README.rst
+++ b/server_env_storage_backend/README.rst
@@ -1,0 +1,33 @@
+
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================================
+Storage Backend - Server Environment Configuration
+==================================================
+
+This module is based on the ``server_environment`` module to use files or environment variable for
+configuration.  Thus we can have a different configuration for each
+environment (dev, test, staging, prod).  This module defines the config
+variables for the ``storage_backend`` module.
+
+Configuration and usage
+=======================
+
+In the configuration file, you can configure the directory_path
+of the storage backend.
+
+Exemple of the section to put in the configuration file or environment
+variable::
+
+    [storage_backend.name_of_the_backend]
+    directory_path = /demo
+
+Credits
+=======
+
+Contributors
+------------
+
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/server_env_storage_backend/__init__.py
+++ b/server_env_storage_backend/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/server_env_storage_backend/__manifest__.py
+++ b/server_env_storage_backend/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Camptocamp (https://www.camptocamp.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Storage Backend - Server Environment",
+    "summary": "Add server environment support to storage backend",
+    "version": "10.0.1.0.0",
+    "category": "Storage",
+    "author": "Camptocamp",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "storage_backend",
+        "server_environment",
+    ],
+    "data": [],
+}

--- a/server_env_storage_backend/models/__init__.py
+++ b/server_env_storage_backend/models/__init__.py
@@ -1,0 +1,1 @@
+from . import storage_backend

--- a/server_env_storage_backend/models/storage_backend.py
+++ b/server_env_storage_backend/models/storage_backend.py
@@ -1,0 +1,23 @@
+# Copyright 2018 Camptocamp (https://www.camptocamp.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import api, fields, models
+
+try:
+    from odoo.addons.server_environment import serv_config
+except ImportError:
+    logging.getLogger("odoo.module").warning(
+        "server_environment not available in addons path. "
+        "server_env_storage_backend_sftp will not be usable"
+    )
+
+
+class StorageBackend(models.Model):
+    _name = "storage.backend"
+    _inherit = ["storage.backend", "server.env.mixin"]
+
+    @property
+    def _server_env_fields(self):
+        return {"directory_path": {}}

--- a/server_env_storage_backend_sftp/README.rst
+++ b/server_env_storage_backend_sftp/README.rst
@@ -1,0 +1,37 @@
+
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================================================
+Storage Backend SFTP - Server Environment Configuration
+=======================================================
+
+This module is based on the ``server_environment`` module to use files or environment variable for
+configuration.  Thus we can have a different configuration for each
+environment (dev, test, staging, prod).  This module defines the config
+variables for the ``storage_backend_sftp`` module.
+
+Configuration and usage
+=======================
+
+In the configuration file, you can configure the server, port, login, password
+of the storage backend.
+
+Exemple of the section to put in the configuration file or environment
+variable::
+
+    [storage_backend.name_of_the_backend]
+    directory_path = /demo
+    sftp_server = sftp.example.com
+    sftp_port = 22
+    sftp_login = foo
+    sftp_password = bar
+
+Credits
+=======
+
+Contributors
+------------
+
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/server_env_storage_backend_sftp/__init__.py
+++ b/server_env_storage_backend_sftp/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/server_env_storage_backend_sftp/__manifest__.py
+++ b/server_env_storage_backend_sftp/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Camptocamp (https://www.camptocamp.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Storage Backend SFTP - Server Environment",
+    "summary": "Add server environment support to storage backend SFTP",
+    "version": "10.0.1.0.0",
+    "category": "Storage",
+    "author": "Camptocamp",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "storage_backend_sftp",
+        "server_env_storage_backend",
+    ],
+    "data": [],
+}

--- a/server_env_storage_backend_sftp/models/__init__.py
+++ b/server_env_storage_backend_sftp/models/__init__.py
@@ -1,0 +1,1 @@
+from . import storage_backend

--- a/server_env_storage_backend_sftp/models/storage_backend.py
+++ b/server_env_storage_backend_sftp/models/storage_backend.py
@@ -1,0 +1,26 @@
+# Copyright 2018 Camptocamp (https://www.camptocamp.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StorageBackend(models.Model):
+    _inherit = "storage.backend"
+
+    @property
+    def _server_env_fields(self):
+        base_fields = super()._server_env_fields
+        sftp_fields = {
+            "sftp_server": {},
+            "sftp_port": {'getter': "getint"},
+            "sftp_login": {},
+            "sftp_password": {
+                # integration with keychain, the 'default' field
+                # is forwarded to keychain's compute/inverse
+                "no_default_field": True,
+                "compute_default": "_compute_password",
+                "inverse_default": "_inverse_password",
+            },
+        }
+        sftp_fields.update(base_fields)
+        return sftp_fields


### PR DESCRIPTION
* [ ] needs https://github.com/OCA/server-env/pull/13
* [ ] needs https://github.com/akretion/storage/pull/41
* [ ] needs https://github.com/akretion/storage/pull/42

It adds the possibility to configure the values either with:
* `server_environment_files` with files per environment
* `SERVER_ENV_CONFIG` multiline environment variable with the config (https://github.com/OCA/server-env/pull/12)

Thanks to the new features of https://github.com/OCA/server-env/pull/13,
it allows as well to have only some fields in configuration files, and
configure the rest on the UI with <field>_env_default fields (they are
not shown, handled by "inverse" methods). This modules also integrates
the password handling with the "keychain" addon, if you don't set any
password in the configuration files/environment variable, then the
password is read/stored from the keychain account.